### PR TITLE
Fix typo under Miscellaneous/TODO comments...

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ assert(date1 === '1/6/2017');
 > George Bernard Shaw
 
 ### TODO comments should be tracked
-TODO comments are great for letting you and your fellow engineers that something
+TODO comments are great for letting you and your fellow engineers know that something
 needs to be fixed later. Sometimes you gotta ship code and wait to fix it
 later. But eventually you'll have to clean it up! That's why you should track it
 and give a corresponding ID from your issue tracking system so you can schedule


### PR DESCRIPTION
Hello,

Thanks for publishing this helpful document. I spotted a typo where the word "know" had been omitted under the Miscellaneous/TODO Comments... section.